### PR TITLE
Adjust timings and option to toggle

### DIFF
--- a/osu.Game.Rulesets.Osu/Configuration/OsuRulesetConfigManager.cs
+++ b/osu.Game.Rulesets.Osu/Configuration/OsuRulesetConfigManager.cs
@@ -19,6 +19,7 @@ namespace osu.Game.Rulesets.Osu.Configuration
             Set(OsuRulesetSetting.SnakingInSliders, true);
             Set(OsuRulesetSetting.SnakingOutSliders, true);
             Set(OsuRulesetSetting.ShowCursorTrail, true);
+            Set(OsuRulesetSetting.ShowSliderTail, false);
         }
     }
 
@@ -26,6 +27,7 @@ namespace osu.Game.Rulesets.Osu.Configuration
     {
         SnakingInSliders,
         SnakingOutSliders,
-        ShowCursorTrail
+        ShowCursorTrail,
+        ShowSliderTail
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableRepeatPoint.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableRepeatPoint.cs
@@ -83,10 +83,12 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
             animDuration = Math.Min(150, repeatPoint.SpanDuration / 2);
 
-            this.Animate(
+            arrow.Animate(
                 d => d.FadeIn(animDuration),
                 d => d.ScaleTo(0.5f).ScaleTo(1f, animDuration * 4, Easing.OutElasticHalf)
             );
+
+            this.FadeIn(HitObject.TimeFadeIn);
         }
 
         protected override void UpdateStateTransforms(ArmedState state)

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableRepeatPoint.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableRepeatPoint.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.MathUtils;
 using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Osu.Configuration;
 using osu.Game.Rulesets.Scoring;
 using osuTK;
 using osu.Game.Skinning;
@@ -25,6 +26,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         private double animDuration;
 
+        private readonly Bindable<bool> showTail = new Bindable<bool>(false);
         private readonly Container scaleContainer;
 
         public DrawableRepeatPoint(RepeatPoint repeatPoint, DrawableSlider drawableSlider)
@@ -67,8 +69,10 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         private readonly IBindable<float> scaleBindable = new Bindable<float>();
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(OsuRulesetConfigManager rulesetConfig)
         {
+            rulesetConfig?.BindWith(OsuRulesetSetting.ShowSliderTail, showTail);
+
             scaleBindable.BindValueChanged(scale => scaleContainer.Scale = new Vector2(scale.NewValue), true);
             scaleBindable.BindTo(HitObject.ScaleBindable);
         }
@@ -87,6 +91,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 d => d.FadeIn(animDuration),
                 d => d.ScaleTo(0.5f).ScaleTo(1f, animDuration * 4, Easing.OutElasticHalf)
             );
+            showTail.BindValueChanged(v => tail.FadeTo(v.NewValue ? 1 : 0), true);
 
             this.FadeIn(HitObject.TimeFadeIn);
         }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTail.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTail.cs
@@ -7,6 +7,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Osu.Configuration;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Skinning;
 using osuTK;
@@ -22,6 +23,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         /// </summary>
         public override bool DisplayResult => false;
 
+        private readonly Bindable<bool> showTail = new Bindable<bool>(false);
         private double animDuration;
         public bool Tracking { get; set; }
 
@@ -67,8 +69,10 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(OsuRulesetConfigManager rulesetConfig)
         {
+            rulesetConfig?.BindWith(OsuRulesetSetting.ShowSliderTail, showTail);
+
             scaleBindable.BindValueChanged(scale => scaleContainer.Scale = new Vector2(scale.NewValue), true);
 
             scaleBindable.BindTo(HitObject.ScaleBindable);
@@ -82,9 +86,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         protected override void UpdateInitialTransforms()
         {
-            base.UpdateInitialTransforms();
+            showTail.BindValueChanged(v => circlePiece.FadeTo(v.NewValue ? 1 : 0), true);
 
-            circlePiece.FadeInFromZero(HitObject.TimeFadeIn);
+            this.FadeIn(HitObject.TimeFadeIn);
         }
 
         protected override void UpdateStateTransforms(ArmedState state)

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -166,6 +166,8 @@ namespace osu.Game.Rulesets.Osu.Objects
                         // if this is to change, we should revisit this.
                         AddNested(TailCircle = new SliderTailCircle(this)
                         {
+                            SpanIndex = e.SpanIndex,
+                            SpanDuration = SpanDuration,
                             StartTime = e.Time,
                             Position = EndPosition,
                             StackHeight = StackHeight

--- a/osu.Game.Rulesets.Osu/Objects/SliderTailCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/SliderTailCircle.cs
@@ -1,7 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Bindables;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu.Judgements;
@@ -15,12 +18,23 @@ namespace osu.Game.Rulesets.Osu.Objects
     /// </summary>
     public class SliderTailCircle : SliderCircle
     {
+        public int SpanIndex { get; set; }
+        public double SpanDuration { get; set; }
+
         private readonly IBindable<int> pathVersion = new Bindable<int>();
 
         public SliderTailCircle(Slider slider)
         {
             pathVersion.BindTo(slider.Path.Version);
             pathVersion.BindValueChanged(_ => Position = slider.EndPosition);
+        }
+
+        protected override void ApplyDefaultsToSelf(ControlPointInfo controlPointInfo, BeatmapDifficulty difficulty)
+        {
+            base.ApplyDefaultsToSelf(controlPointInfo, difficulty);
+
+            if (SpanIndex > 0)
+                TimePreempt = Math.Min(SpanDuration * 2, TimePreempt + SpanDuration);
         }
 
         public override Judgement CreateJudgement() => new OsuSliderTailJudgement();

--- a/osu.Game.Rulesets.Osu/UI/OsuSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuSettingsSubsection.cs
@@ -39,6 +39,11 @@ namespace osu.Game.Rulesets.Osu.UI
                     LabelText = "Cursor trail",
                     Bindable = config.GetBindable<bool>(OsuRulesetSetting.ShowCursorTrail)
                 },
+                new SettingsCheckbox
+                {
+                    LabelText = "Slider tail",
+                    Bindable = config.GetBindable<bool>(OsuRulesetSetting.ShowSliderTail)
+                },
             };
         }
     }


### PR DESCRIPTION
Adjusted some timings to make sure the tail shows up correctly timed when after a reverse point.

I also added an option that let's you change the visibility of the slider tail. I don't think these types of settings will be handled this way in the future but added it temporarily.